### PR TITLE
Update About page with current roles and interests

### DIFF
--- a/about.md
+++ b/about.md
@@ -12,7 +12,7 @@ I've been writing software professionally since I was a teenager, which means al
 
 Alongside Auror I'm CTO and co-founder of [Worklibrary](https://worklibrary.ai/) (formerly Zoolibrary), and a fractional CTO at [Birdeey](https://birdeey.com/) — both companies I'm genuinely excited about.
 
-Previously I was VP of Engineering at Pushpay (joining as engineer #5 and helping grow the team ~10x through hyper-growth), CTO at First AML, and have run my boutique consultancy DevDefined Limited along the way.
+Previously I was VP of Engineering at Pushpay (joining as engineer #5 and helping grow the team ~10x through hyper-growth) and CTO at First AML.
 
 ### More information
 

--- a/about.md
+++ b/about.md
@@ -6,38 +6,32 @@ permalink: /about/
 
 Hi!
 
-My name is Alex Henderson, and I live in Auckland New Zealand.
+I'm Alex Henderson, and I live in Titirangi, Auckland with my wife Renee and our 12-year-old daughter Ivy.
 
-I'm a software engineer with 18+ years of working experience in the industry.
+I've been writing software professionally since I was 17, which means almost 30 years of shipping things, breaking things, and (mostly) learning from the latter. I'm currently a Distinguished Engineer at [Auror](https://www.auror.co/), where I help shape engineering strategy as we keep scaling.
 
-I provide development services to companies in New Zealand and around the world, generally through long-term consulting engagements with my boutique software consultancy DevDefined Limited.
+Alongside Auror I'm CTO and co-founder of [Worklibrary](https://worklibrary.ai/) (formerly Zoolibrary), and a fractional CTO at [Birdeey](https://birdeey.com/) — both companies I'm genuinely excited about.
 
-I have been consulting with Pushpay limited for over 4 years where I provide my services as a Principal engineer - I began working with the Pushpay team as engineer #5 and have helped grow the engineering team to 10x that size in one of the fastest growing New Zealand companies while helping ensuring we maintain a robust software architecture to build upon into the future.
+Previously I was VP of Engineering at Pushpay (joining as engineer #5 and helping grow the team ~10x through hyper-growth), CTO at First AML, and have run my boutique consultancy DevDefined Limited along the way.
 
-### More Information
+### More information
 
-I have a love of back end services, APIs and distributed systems as well as coaching and growing developers.
+My interests these days span the full arc of building and scaling SaaS businesses — product, engineering, and the messy bits in between. I'm particularly drawn to the growth and scaling stage, where the org you have isn't quite the org you need yet, and you have to figure out how to get there without breaking what's working.
 
-My current interests in software engineering are broad and include:
+A non-exhaustive list of things I'm thinking about a lot right now:
 
-* AWS.
-* .Net core.
-* Linux.
-* Containers (Docker, Kube, ECS, EKS etc)
-* Streams (Kinesis/Kafka)
-* Data stores of all kinds.
-* Microservices
-* Solution design and architecture
-* Engineer & Product interactions
-* Feature planning and delivery
-* Learning how to cope in hyper-growth companies.
+* Growing and scaling SaaS businesses (the people side and the systems side, equally).
+* AI and agentic coding — investing heavily in both how we work and what we ship.
+* Engineering leadership, coaching, and helping senior engineers find their next gear.
+* Product/engineering interactions and how to make that boundary actually work.
+* Distributed systems, APIs, and back-end services (still a soft spot for me).
+* Solution design and architecture in brown-field environments.
+* Feature planning, delivery, and the underrated craft of estimation.
 
-I enjoy being wrong and having my opinions being challenged because it reminds me of why I love software engineering!
+My main languages and tools are C# / .NET, Python, TypeScript / JavaScript, and React — though I try not to be too precious about any of them.
 
-I always prefer brown-fields to green-fields.
+I still enjoy being wrong and having my opinions challenged — it's a good reminder of why I love this craft. I still prefer brown-fields to green-fields. I still hate meetings without agendas, and weak opinions held strongly.
 
-I hate meetings without agendas, and weak opinions that are held strongly.
-
-Oh and I'm just a little bitter now and again... but I only use that trait for good.
+And yeah, I'm still just a little bitter now and again — but I only use that trait for good.
 
 *This is my professional blog, and all opinions held here are my own and do not represent the opinions of the companies I work with.*

--- a/about.md
+++ b/about.md
@@ -6,7 +6,7 @@ permalink: /about/
 
 Hi!
 
-I'm Alex Henderson, and I live in Titirangi, Auckland with my wife Renee and our 12-year-old daughter Ivy.
+I'm Alex Henderson, and I live in Titirangi, Auckland with my wife Renee and our daughter Ivy.
 
 I've been writing software professionally since I was 17, which means almost 30 years of shipping things, breaking things, and (mostly) learning from the latter. I'm currently a Distinguished Engineer at [Auror](https://www.auror.co/), where I help shape engineering strategy as we keep scaling.
 

--- a/about.md
+++ b/about.md
@@ -8,7 +8,7 @@ Hi!
 
 I'm Alex Henderson, and I live in Titirangi, Auckland with my wife Renee and our daughter Ivy.
 
-I've been writing software professionally since I was 17, which means almost 30 years of shipping things, breaking things, and (mostly) learning from the latter. I'm currently a Distinguished Engineer at [Auror](https://www.auror.co/), where I help shape engineering strategy as we keep scaling.
+I've been writing software professionally since I was a teenager, which means almost 30 years of shipping things, breaking things, and (mostly) learning from the latter. I'm currently a Distinguished Engineer at [Auror](https://www.auror.co/), where I help shape engineering strategy as we keep scaling.
 
 Alongside Auror I'm CTO and co-founder of [Worklibrary](https://worklibrary.ai/) (formerly Zoolibrary), and a fractional CTO at [Birdeey](https://birdeey.com/) — both companies I'm genuinely excited about.
 


### PR DESCRIPTION
## Summary
- Refresh bio with current roles: Distinguished Engineer at Auror, CTO/co-founder of Worklibrary, fractional CTO at Birdeey
- Update prior roles (Pushpay VP Eng, First AML CTO) and personal details (Titirangi, Renee, Ivy, ~30 years since starting at 17)
- Broaden the More Information section to cover product, scaling SaaS, AI & agentic coding, and current stack (C#/.NET, Python, TS/JS, React)

## Test plan
- [ ] Preview the rendered About page and check links to auror.co, worklibrary.ai, birdeey.com resolve
- [ ] Skim for tone consistency with recent posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)